### PR TITLE
Get payday leap years

### DIFF
--- a/calculator.py
+++ b/calculator.py
@@ -32,8 +32,29 @@ def is_payday_leap_year(year, payday, frequency='biweekly'):
         result = False
     return result
 
-def get_payday_leap_years():
-    pass
+def get_payday_leap_years(payday, frequency='biweekly', count=5):
+    """Get the next n payday leap years.
+
+    Return a list of the next n payday leap years, where n is specified
+    by `count`.
+
+    Args:
+        payday (date): A payday from the specified pay calendar.
+        frequency (str): Pay frequency. Valid values are 'weekly'
+            or 'biweekly'. Default is 'biweekly'.
+        count (int): The number of payday leap years to return. Default is 5.
+
+    Returns:
+        A list of ints.
+    """
+    results = []
+    # Start counting from the current year.
+    year = date.today().year
+    while len(results) < count:
+        if is_payday_leap_year(year, payday, frequency):
+            results.append(year)
+        year += 1
+    return results
 
 if __name__ == '__main__':
     year = 2018
@@ -44,4 +65,3 @@ if __name__ == '__main__':
             year, is_payday_leap_year(year, payday)
         ))
         year += 1
-

--- a/calculator.py
+++ b/calculator.py
@@ -32,6 +32,9 @@ def is_payday_leap_year(year, payday, frequency='biweekly'):
         result = False
     return result
 
+def get_payday_leap_years():
+    pass
+
 if __name__ == '__main__':
     year = 2018
     # January 11, 2018

--- a/tests.py
+++ b/tests.py
@@ -3,7 +3,7 @@ from datetime import date
 
 from calculator import is_payday_leap_year, get_payday_leap_years
 
-class CalculatorTestCase(unittest.TestCase):
+class IsPaydayLeapYearTestCase(unittest.TestCase):
 
     def test_thursday_2018_is_false(self):
         payday = date(2018, 1, 11)
@@ -49,8 +49,24 @@ class GetPaydayLeapYearsTestCase(unittest.TestCase):
     def test_7_26_2018_returns_correct_years(self):
         payday = date(2018, 7, 26)
         expected = [2026, 2037, 2048, 2060, 2071]
-        actual = get_payday_leap_years(payday, count=5)
-        self.assertEqual(expected, actual)
+        results = get_payday_leap_years(payday)
+        self.assertEqual(results, expected)
+    
+    def test_7_26_2018_returns_correct_years_weekly_frequency(self):
+        payday = date(2018, 7, 26)
+        expected = [2020, 2026, 2032, 2037, 2043]
+        results = get_payday_leap_years(payday, frequency='weekly')
+        self.assertEqual(results, expected)
+
+    def test_non_default_count(self):
+        payday = date(2018, 7, 26)
+        results = get_payday_leap_years(payday, count=10)
+        self.assertEqual(len(results), 10)
+
+    def test_zero_count_returns_empty_result_set(self):
+        payday = date(2018, 7, 26)
+        results = get_payday_leap_years(payday, count=0)
+        self.assertEqual(len(results), 0)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/tests.py
+++ b/tests.py
@@ -1,7 +1,7 @@
 import unittest
 from datetime import date
 
-from calculator import is_payday_leap_year
+from calculator import is_payday_leap_year, get_payday_leap_years
 
 class CalculatorTestCase(unittest.TestCase):
 
@@ -43,6 +43,14 @@ class CalculatorTestCase(unittest.TestCase):
         self.assertTrue(is_payday_leap_year(2015, payday, 'not_valid'))
         # Would be True for weekly - checking this doesn't happen.
         self.assertFalse(is_payday_leap_year(2020, payday, 'not_valid'))
+
+class GetPaydayLeapYearsTestCase(unittest.TestCase):
+    
+    def test_7_26_2018_returns_correct_years(self):
+        payday = date(2018, 7, 26)
+        expected = [2026, 2037, 2048, 2060, 2071]
+        actual = get_payday_leap_years(payday, count=5)
+        self.assertEqual(expected, actual)
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)


### PR DESCRIPTION
Implement the `get_payday_leap_years()` function to return a list of the next `n` payday leap years. Rename the existing `CalculatorTestCase` test class to `IsPaydayLeapYearTestCase`.